### PR TITLE
:bug: 連打で同一タスクが複数回登録されるバグを修正 (Fixes #11)

### DIFF
--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -109,10 +109,10 @@ export const Index: VFC = () => {
               type="text"
               value={textToday}
               onChange={handleChangeTextToday}
-              onKeyPress={(e) => {
+              onKeyPress={async (e) => {
                 if (e.key === "Enter" && !isSending) {
                   setIsSending(true);
-                  handleAddToday();
+                  await handleAddToday();
                   setIsSending(false);
                 }
               }}
@@ -140,10 +140,10 @@ export const Index: VFC = () => {
               type="text"
               value={textTomorrow}
               onChange={handleChangeTextTomorrow}
-              onKeyPress={(e) => {
+              onKeyPress={async (e) => {
                 if (e.key === "Enter" && !isSending) {
                   setIsSending(true);
-                  handleAddTomorrow();
+                  await handleAddTomorrow();
                   setIsSending(false);
                 }
               }}
@@ -171,10 +171,10 @@ export const Index: VFC = () => {
               type="text"
               value={textOther}
               onChange={handleChangeTextOther}
-              onKeyPress={(e) => {
+              onKeyPress={async (e) => {
                 if (e.key === "Enter" && !isSending) {
                   setIsSending(true);
-                  handleAddOther();
+                  await handleAddOther();
                   setIsSending(false);
                 }
               }}

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -14,24 +14,31 @@ export const Index: VFC = () => {
   const [todoToday, setTodoToday] = useState<TodoType[]>([]);
   const [todoTomorrow, setTodoTomorrow] = useState<TodoType[]>([]);
   const [todoOther, setTodoOther] = useState<TodoType[]>([]);
+  const [isSending, setIsSending] = useState<boolean>(false);
 
   const handleChangeTextToday = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
+      setIsSending(true);
       setTextToday(e.target.value);
+      setIsSending(false);
     },
     []
   );
 
   const handleChangeTextTomorrow = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
+      setIsSending(true);
       setTextTomorrow(e.target.value);
+      setIsSending(false);
     },
     []
   );
 
   const handleChangeTextOther = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
+      setIsSending(true);
       setTextOther(e.target.value);
+      setIsSending(false);
     },
     []
   );
@@ -109,7 +116,7 @@ export const Index: VFC = () => {
               value={textToday}
               onChange={handleChangeTextToday}
               onKeyPress={(e) => {
-                if (e.key === "Enter") {
+                if (e.key === "Enter" && !isSending) {
                   handleAddToday();
                 }
               }}
@@ -138,7 +145,7 @@ export const Index: VFC = () => {
               value={textTomorrow}
               onChange={handleChangeTextTomorrow}
               onKeyPress={(e) => {
-                if (e.key === "Enter") {
+                if (e.key === "Enter" && !isSending) {
                   handleAddTomorrow();
                 }
               }}
@@ -167,7 +174,7 @@ export const Index: VFC = () => {
               value={textOther}
               onChange={handleChangeTextOther}
               onKeyPress={(e) => {
-                if (e.key === "Enter") {
+                if (e.key === "Enter" && !isSending) {
                   handleAddOther();
                 }
               }}

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -18,27 +18,21 @@ export const Index: VFC = () => {
 
   const handleChangeTextToday = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setIsSending(true);
       setTextToday(e.target.value);
-      setIsSending(false);
     },
     []
   );
 
   const handleChangeTextTomorrow = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setIsSending(true);
       setTextTomorrow(e.target.value);
-      setIsSending(false);
     },
     []
   );
 
   const handleChangeTextOther = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      setIsSending(true);
       setTextOther(e.target.value);
-      setIsSending(false);
     },
     []
   );
@@ -117,7 +111,9 @@ export const Index: VFC = () => {
               onChange={handleChangeTextToday}
               onKeyPress={(e) => {
                 if (e.key === "Enter" && !isSending) {
+                  setIsSending(true);
                   handleAddToday();
+                  setIsSending(false);
                 }
               }}
               className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 caret-[#F43F5E]"
@@ -146,7 +142,9 @@ export const Index: VFC = () => {
               onChange={handleChangeTextTomorrow}
               onKeyPress={(e) => {
                 if (e.key === "Enter" && !isSending) {
+                  setIsSending(true);
                   handleAddTomorrow();
+                  setIsSending(false);
                 }
               }}
               className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 caret-[#F43F5E]"
@@ -175,7 +173,9 @@ export const Index: VFC = () => {
               onChange={handleChangeTextOther}
               onKeyPress={(e) => {
                 if (e.key === "Enter" && !isSending) {
+                  setIsSending(true);
                   handleAddOther();
+                  setIsSending(false);
                 }
               }}
               className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 caret-[#F43F5E]"


### PR DESCRIPTION
## 変更内容（必須）

例）Todo リストを追加できるようにするため

- タスク登録時にEnterキー連打で同一タスクが複数回登録されるバグを解消するため
-

## 確認して欲しい項目（必須）

- [ ] Enterキーを連打したときにタスクが一度のみ登録されることを確認
- [ ]

## どうやって確認するのか（必須）

1. タスクを入力し、Enterキーを連打
1.

## 新たな課題

-
-

## 備考

- 私の環境だと再現性が低いバグなので、確認していただけると助かります
-
