### PR TITLE
🐛 タスク編集時に全部消すと表示がplaceholderのみになるバグ

### DIFF
--- a/src/component/taskInput/index.tsx
+++ b/src/component/taskInput/index.tsx
@@ -25,8 +25,10 @@ export const TaskInput = (props: any) => {
       } else {
         alert("タスクの変更に失敗しました");
       }
+    } else {
+      setText(item.task);
     }
-  }, [text, user, item.id, updateTodo]);
+  }, [text, user, item.id, item.task, updateTodo]);
 
   return (
     <>
@@ -52,7 +54,7 @@ export const TaskInput = (props: any) => {
           }
         }}
         className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 cursor-pointer caret-[#F43F5E]"
-        placeholder={item.task}
+        // placeholder={item.task}
       />
     </>
   );

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { useEffect, useState } from "react";
 import { HiPlusCircle } from "react-icons/hi";
 import { Dndkit } from "src/component/dndkit";
-import { TaskInput } from "src/component/Input";
+import { TaskInput } from "src/component/taskInput";
 import type { TodoType } from "src/lib/SupabaseClient";
 import { addTodo, getTodo } from "src/lib/SupabaseClient";
 


### PR DESCRIPTION
Fixes #27

## 変更内容（必須）

- placeholderを表示させないように変更した
- 全ての文字を消してしまったとき、確定させても変更はされず、文字も再び表示されるようにした
- parsingerrorが出ていたので、コンポーネント名を変えました

## 確認して欲しい項目（必須）

- [x] 全ての文字を消してエンターもしくは他の要素をクリックしても、編集されないようになっているか
- [x] placeholderはなくなっているか

## どうやって確認するのか（必須）

1. 全ての文字を消してエンターもしくは他の要素をクリック


