### PR TITLE
タスクを追加するボタンのUI/UX向上、その他変更

### DIFF
--- a/src/component/NewTask/index.tsx
+++ b/src/component/NewTask/index.tsx
@@ -6,7 +6,7 @@ import { addTodo } from "src/lib/SupabaseClient";
 
 export const NewTask = (props: any) => {
   const { user } = Auth.useUser();
-  const { day, updateTodo } = props;
+  const { day, taskColor, updateTodo } = props;
   const [isComplete, setIsComplete] = useState<boolean>(false);
   const [isSending, setIsSending] = useState<boolean>(false);
   const inputstyle = "line-through text-[#C2C6D2]";
@@ -51,7 +51,7 @@ export const NewTask = (props: any) => {
         {isAddTask ? (
           <>
             <RadioButton2
-              centerColor="bg-[#F43F5E]"
+              centerColor={taskColor}
               setIsCompleted={setIsComplete}
               isCompleted={isComplete}
             />

--- a/src/component/NewTask/index.tsx
+++ b/src/component/NewTask/index.tsx
@@ -1,0 +1,101 @@
+import { Auth } from "@supabase/ui";
+import { useCallback, useState } from "react";
+import { HiPlusSm } from "react-icons/hi";
+import { RadioButton2 } from "src/component/RadioButton/radiobutton";
+import { addTodo } from "src/lib/SupabaseClient";
+
+export const NewTask = (props: any) => {
+  const { user } = Auth.useUser();
+  const { day, updateTodo } = props;
+  const [isComplete, setIsComplete] = useState<boolean>(false);
+  const [isSending, setIsSending] = useState<boolean>(false);
+  const inputstyle = "line-through text-[#C2C6D2]";
+  const lineThrough: string = isComplete ? inputstyle : "";
+  const [text, setText] = useState<string>("");
+  const [isAddTask, setAddTask] = useState<boolean>(false);
+
+  const handleChangeText = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.value.length < 100) {
+        setText(e.target.value);
+      } else {
+        alert("100文字以内で入力してください");
+      }
+    },
+    []
+  );
+
+  const handleAddTask = useCallback(
+    async (day: "today" | "tomorrow" | "other", isComplete: boolean) => {
+      if (text && user) {
+        const uid = user.id;
+        const isSuccess = await addTodo(uid, text, day, isComplete);
+        if (isSuccess) {
+          updateTodo();
+          setText("");
+        } else {
+          alert("タスクの追加に失敗しました");
+        }
+      }
+    },
+    [text, user, updateTodo]
+  );
+
+  const handleClickButton = () => {
+    setAddTask(true);
+  };
+
+  return (
+    <>
+      <div className="flex justify-start items-center py-2 px-1">
+        {isAddTask ? (
+          <>
+            <RadioButton2
+              centerColor="bg-[#F43F5E]"
+              setIsCompleted={setIsComplete}
+              isCompleted={isComplete}
+            />
+            <input
+              type="text"
+              value={text}
+              onChange={handleChangeText}
+              onKeyPress={async (e) => {
+                if (e.key === "Enter" && !isSending) {
+                  setIsSending(true);
+                  await handleAddTask(day, isComplete);
+                  setIsSending(false);
+                }
+              }}
+              onBlur={async () => {
+                //同じ文言であれば編集しないようにする
+                if (!isSending) {
+                  setIsSending(true);
+                  await handleAddTask(day, isComplete);
+                  setIsSending(false);
+                }
+                setAddTask(false);
+              }}
+              className={`h-5 flex-1 placeholder:text-[#C2C6D2] truncate border-0 focus:ring-0 caret-[#F43F5E] ${lineThrough}`}
+              autoFocus
+              disabled={isComplete}
+            />
+          </>
+        ) : (
+          <>
+            <div
+              className={`flex justify-center  w-5 h-5 rounded-full ring-2 ring-gray-300 bg-gray-300`}
+            >
+              <HiPlusSm size={20} className="text-[#ffffff]" />
+            </div>
+            <button
+              onClick={handleClickButton}
+              className="ml-3 h-5 leading-5 placeholder:text-[#C2C6D2] text-gray-400 border-0 focus:ring-0 caret-[#F43F5E]"
+            >
+              タスクを追加する
+            </button>
+          </>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/component/RadioButton/index.tsx
+++ b/src/component/RadioButton/index.tsx
@@ -9,7 +9,7 @@ type Style = {
 
 export const RadioButton: VFC<Style> = (props) => {
   const { centerColor, handleEditIsComplete, item } = props;
-  const bgColor: string = item.iscomplete ? `bg-[${centerColor}]` : "bg-white";
+  const bgColor: string = item.iscomplete ? centerColor : "bg-white";
 
   const handleJudgeCompleted = useCallback(() => {
     handleEditIsComplete(item.id, !item.iscomplete);

--- a/src/component/RadioButton/index.tsx
+++ b/src/component/RadioButton/index.tsx
@@ -18,7 +18,7 @@ export const RadioButton: VFC<Style> = (props) => {
   return (
     <>
       <div
-        className={`flex justify-center p-[0.15rem] w-5 h-5 rounded-full ring-2 ring-gray-200 mr-1`}
+        className={`flex justify-center p-[0.15rem] w-5 h-5 rounded-full ring-2 ring-gray-200`}
         onClick={handleJudgeCompleted}
       >
         <button

--- a/src/component/RadioButton/index.tsx
+++ b/src/component/RadioButton/index.tsx
@@ -9,7 +9,7 @@ type Style = {
 
 export const RadioButton: VFC<Style> = (props) => {
   const { centerColor, handleEditIsComplete, item } = props;
-  const bgColor: string = item.iscomplete ? centerColor : "bg-white";
+  const bgColor: string = item.iscomplete ? `bg-[${centerColor}]` : "bg-white";
 
   const handleJudgeCompleted = useCallback(() => {
     handleEditIsComplete(item.id, !item.iscomplete);
@@ -22,7 +22,7 @@ export const RadioButton: VFC<Style> = (props) => {
         onClick={handleJudgeCompleted}
       >
         <button
-          className={`outline-none w-full h-full rounded-full ${bgColor}`}
+          className={`outline-none w-full h-full rounded-full  ${bgColor}`}
         />
       </div>
     </>

--- a/src/component/RadioButton/radiobutton.tsx
+++ b/src/component/RadioButton/radiobutton.tsx
@@ -8,7 +8,7 @@ type Style = {
 
 export const RadioButton2: VFC<Style> = (props) => {
   const { centerColor, isCompleted, setIsCompleted } = props;
-  const bgColor: string = isCompleted ? centerColor : "bg-white";
+  const bgColor: string = isCompleted ? `bg-[${centerColor}]` : "bg-white";
 
   const handleJudgeCompleted = () => {
     setIsCompleted(!isCompleted);

--- a/src/component/RadioButton/radiobutton.tsx
+++ b/src/component/RadioButton/radiobutton.tsx
@@ -8,7 +8,7 @@ type Style = {
 
 export const RadioButton2: VFC<Style> = (props) => {
   const { centerColor, isCompleted, setIsCompleted } = props;
-  const bgColor: string = isCompleted ? `bg-[${centerColor}]` : "bg-white";
+  const bgColor: string = isCompleted ? centerColor : "bg-white";
 
   const handleJudgeCompleted = () => {
     setIsCompleted(!isCompleted);

--- a/src/component/RadioButton/radiobutton.tsx
+++ b/src/component/RadioButton/radiobutton.tsx
@@ -1,0 +1,29 @@
+import type { VFC } from "react";
+
+type Style = {
+  centerColor: string;
+  isCompleted: boolean;
+  setIsCompleted: any;
+};
+
+export const RadioButton2: VFC<Style> = (props) => {
+  const { centerColor, isCompleted, setIsCompleted } = props;
+  const bgColor: string = isCompleted ? centerColor : "bg-white";
+
+  const handleJudgeCompleted = () => {
+    setIsCompleted(!isCompleted);
+  };
+
+  return (
+    <>
+      <div
+        className={`flex justify-center p-[0.15rem] w-5 h-5 rounded-full ring-2 ring-gray-200 mr-1`}
+        onClick={handleJudgeCompleted}
+      >
+        <button
+          className={`outline-none w-full h-full rounded-full ${bgColor}`}
+        />
+      </div>
+    </>
+  );
+};

--- a/src/component/TaskWrap/index.tsx
+++ b/src/component/TaskWrap/index.tsx
@@ -8,7 +8,7 @@ import { editIsComplete } from "src/lib/SupabaseClient";
 
 export const TaskWrap = (props: any) => {
   const { user } = Auth.useUser();
-  const { item, updateTodo } = props;
+  const { item, taskColor, updateTodo } = props;
 
   const handleEditIsComplete = useCallback(
     async (itemId: number, itemiscomplete: boolean) => {
@@ -30,7 +30,7 @@ export const TaskWrap = (props: any) => {
       <li className="group flex justify-start py-2 px-1">
         <RadioButton
           handleEditIsComplete={handleEditIsComplete}
-          centerColor="bg-[#F43F5E]"
+          centerColor={taskColor}
           item={item}
         />
         <TaskInput item={item} updateTodo={updateTodo} />

--- a/src/component/TaskWrap/index.tsx
+++ b/src/component/TaskWrap/index.tsx
@@ -1,0 +1,46 @@
+import { Auth } from "@supabase/ui";
+import { useCallback } from "react";
+import { CgTrash } from "react-icons/cg";
+import { MdOutlineContentCopy } from "react-icons/md";
+import { RadioButton } from "src/component/RadioButton";
+import { TaskInput } from "src/component/taskInput";
+import { editIsComplete } from "src/lib/SupabaseClient";
+
+export const TaskWrap = (props: any) => {
+  const { user } = Auth.useUser();
+  const { item, updateTodo } = props;
+
+  const handleEditIsComplete = useCallback(
+    async (itemId: number, itemiscomplete: boolean) => {
+      if (user) {
+        const isSuccess = await editIsComplete(itemId, itemiscomplete);
+        if (isSuccess) {
+          updateTodo();
+        } else {
+          alert("isComplete処理に失敗しました。");
+        }
+      } else {
+      }
+    },
+    [user, updateTodo]
+  );
+
+  return (
+    <>
+      <li className="group flex justify-start py-2 px-1">
+        <RadioButton
+          handleEditIsComplete={handleEditIsComplete}
+          centerColor="bg-[#F43F5E]"
+          item={item}
+        />
+        <TaskInput item={item} updateTodo={updateTodo} />
+        <div className="invisible group-hover:visible">
+          <div className="flex invisible group-hover:visible gap-2 items-center mr-6 text-[#C2C6D2] hover:cursor-pointer">
+            <MdOutlineContentCopy />
+            <CgTrash />
+          </div>
+        </div>
+      </li>
+    </>
+  );
+};

--- a/src/component/taskInput/index.tsx
+++ b/src/component/taskInput/index.tsx
@@ -56,7 +56,7 @@ export const TaskInput = (props: any) => {
             setIsSending(false);
           }
         }}
-        className={`h-5 placeholder:text-[#C2C6D2] truncate border-0 focus:ring-0 cursor-pointer caret-[#F43F5E] ${lineThrough}`}
+        className={`h-5 flex-1 placeholder:text-[#C2C6D2] truncate border-0 focus:ring-0 ml-1 caret-[#F43F5E] ${lineThrough}`}
         disabled={item.iscomplete}
       />
     </>

--- a/src/lib/SupabaseClient.ts
+++ b/src/lib/SupabaseClient.ts
@@ -27,12 +27,18 @@ export type TodoType = {
 export const addTodo = async (
   uid: string,
   task: string,
-  taskType: TaskType
+  taskType: TaskType,
+  isComplete: boolean
 ) => {
   const deadline = taskType == "other" ? null : getDate(taskType);
-  const { error } = await client
-    .from("todos")
-    .insert([{ uid: uid, task: task, deadline: deadline }]);
+  const { error } = await client.from("todos").insert([
+    {
+      uid: uid,
+      task: task,
+      deadline: deadline,
+      iscomplete: isComplete,
+    },
+  ]);
   if (error) {
     return false;
   } else {

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -33,7 +33,8 @@ export const Index: VFC = () => {
     {
       id: 1,
       header: "今日する",
-      color: "#F43F5E",
+      color: "text-[#F43F5E]",
+      bgColor: "bg-[#F43F5E]",
       taskArray: todoToday,
       day: "today",
       setState: setTodoToday,
@@ -41,7 +42,8 @@ export const Index: VFC = () => {
     {
       id: 2,
       header: "明日する",
-      color: "#FB923C",
+      color: "text-[#FB923C]",
+      bgColor: "bg-[#FB923C]",
       taskArray: todoTomorrow,
       day: "tomorrow",
       setState: setTodoTomorrow,
@@ -49,7 +51,8 @@ export const Index: VFC = () => {
     {
       id: 3,
       header: "今度する",
-      color: "#FBBF24",
+      color: "text-[#FBBF24]",
+      bgColor: "bg-[#FBBF24]",
       taskArray: todoOther,
       day: "other",
       setState: setTodoOther,
@@ -61,7 +64,7 @@ export const Index: VFC = () => {
       <div className="grid grid-cols-3 gap-4 my-8 mx-12">
         {mapTaskElement.map((task) => (
           <div className="col-span-1" key={task.id}>
-            <div className={`text-xl font-bold text-[${task.color}]`}>
+            <div className={`text-xl font-bold ${task.color}`}>
               {task.header}
             </div>
             <div className="mt-6">
@@ -71,14 +74,14 @@ export const Index: VFC = () => {
                     key={`item-${item.id}`}
                     updateTodo={updateTodo}
                     item={item}
-                    taskColor={task.color}
+                    taskColor={task.bgColor}
                   />
                 ))}
               </ul>
               <NewTask
                 day={task.day}
                 updateTodo={updateTodo}
-                taskColor={task.color}
+                taskColor={task.bgColor}
               />
             </div>
           </div>

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -71,10 +71,15 @@ export const Index: VFC = () => {
                     key={`item-${item.id}`}
                     updateTodo={updateTodo}
                     item={item}
+                    taskColor={task.color}
                   />
                 ))}
               </ul>
-              <NewTask day={task.day} updateTodo={updateTodo} />
+              <NewTask
+                day={task.day}
+                updateTodo={updateTodo}
+                taskColor={task.color}
+              />
             </div>
           </div>
         ))}

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,64 +1,20 @@
-import { Auth } from "@supabase/ui";
 import type { VFC } from "react";
 import { useCallback } from "react";
 import { useEffect, useState } from "react";
-import { CgTrash } from "react-icons/cg";
-import { HiPlusCircle } from "react-icons/hi";
-import { MdOutlineContentCopy } from "react-icons/md";
 import { Dndkit } from "src/component/dndkit";
-import { RadioButton } from "src/component/RadioButton";
-import { TaskInput } from "src/component/taskInput";
+import { NewTask } from "src/component/NewTask";
+import { TaskWrap } from "src/component/TaskWrap";
 import type { TodoType } from "src/lib/SupabaseClient";
-import { editIsComplete } from "src/lib/SupabaseClient";
-import { addTodo, getTodo, moveTodo } from "src/lib/SupabaseClient";
+import { getTodo, moveTodo } from "src/lib/SupabaseClient";
 
 export const Index: VFC = () => {
-  const { user } = Auth.useUser();
-  const [textToday, setTextToday] = useState<string>("");
-  const [textTomorrow, setTextTomorrow] = useState<string>("");
-  const [textOther, setTextOther] = useState<string>("");
   const [todoToday, setTodoToday] = useState<TodoType[]>([]);
   const [todoTomorrow, setTodoTomorrow] = useState<TodoType[]>([]);
   const [todoOther, setTodoOther] = useState<TodoType[]>([]);
-  const [isSending, setIsSending] = useState<boolean>(false);
-  const [isAddTask, setAddTask] = useState<boolean>(false);
 
   //テスト用
   const [target, setTarget] = useState<number>(0);
   const [position, setPosition] = useState<number>(0);
-
-  const handleChangeTextToday = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.value.length < 100) {
-        setTextToday(e.target.value);
-      } else {
-        alert("100文字以内で入力してください");
-      }
-    },
-    []
-  );
-
-  const handleChangeTextTomorrow = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.value.length < 100) {
-        setTextTomorrow(e.target.value);
-      } else {
-        alert("100文字以内で入力してください");
-      }
-    },
-    []
-  );
-
-  const handleChangeTextOther = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.value.length < 100) {
-        setTextOther(e.target.value);
-      } else {
-        alert("100文字以内で入力してください");
-      }
-    },
-    []
-  );
 
   const updateTodo = useCallback(async () => {
     let data = await getTodo("today");
@@ -68,60 +24,6 @@ export const Index: VFC = () => {
     data = await getTodo("other");
     setTodoOther(data);
   }, []);
-
-  const handleEditIsComplete = useCallback(
-    async (itemId: number, itemiscomplete: boolean) => {
-      if (user) {
-        const isSuccess = await editIsComplete(itemId, itemiscomplete);
-        if (isSuccess) {
-          updateTodo();
-        } else {
-          alert("isComplete処理に失敗しました。");
-        }
-      } else {
-      }
-    },
-    [user, updateTodo]
-  );
-
-  const handleAddToday = useCallback(async () => {
-    if (textToday && user) {
-      const uid = user.id;
-      const isSuccess = await addTodo(uid, textToday, "today");
-      if (isSuccess) {
-        updateTodo();
-        setTextToday("");
-      } else {
-        alert("タスクの追加に失敗しました");
-      }
-    }
-  }, [textToday, user, updateTodo]);
-
-  const handleAddTomorrow = useCallback(async () => {
-    if (textTomorrow && user) {
-      const uid = user.id;
-      const isSuccess = await addTodo(uid, textTomorrow, "tomorrow");
-      if (isSuccess) {
-        updateTodo();
-        setTextTomorrow("");
-      } else {
-        alert("タスクの追加に失敗しました");
-      }
-    }
-  }, [textTomorrow, user, updateTodo]);
-
-  const handleAddOther = useCallback(async () => {
-    if (textOther && user) {
-      const uid = user.id;
-      const isSuccess = await addTodo(uid, textOther, "other");
-      if (isSuccess) {
-        updateTodo();
-        setTextOther("");
-      } else {
-        alert("タスクの追加に失敗しました");
-      }
-    }
-  }, [textOther, user, updateTodo]);
 
   useEffect(() => {
     updateTodo();
@@ -133,9 +35,7 @@ export const Index: VFC = () => {
       header: "今日する",
       color: "#F43F5E",
       taskArray: todoToday,
-      value: textToday,
-      handleChangeEvent: handleChangeTextToday,
-      addTodoFunction: handleAddToday,
+      day: "today",
       setState: setTodoToday,
     },
     {
@@ -143,9 +43,7 @@ export const Index: VFC = () => {
       header: "明日する",
       color: "#FB923C",
       taskArray: todoTomorrow,
-      value: textTomorrow,
-      handleChangeEvent: handleChangeTextTomorrow,
-      addTodoFunction: handleAddTomorrow,
+      day: "tomorrow",
       setState: setTodoTomorrow,
     },
     {
@@ -153,16 +51,10 @@ export const Index: VFC = () => {
       header: "今度する",
       color: "#FBBF24",
       taskArray: todoOther,
-      value: textOther,
-      handleChangeEvent: handleChangeTextOther,
-      addTodoFunction: handleAddOther,
+      day: "other",
       setState: setTodoOther,
     },
   ];
-
-  const handleClickButton = () => {
-    setAddTask(true);
-  };
 
   return (
     <>
@@ -175,73 +67,14 @@ export const Index: VFC = () => {
             <div className="mt-6">
               <ul>
                 {task.taskArray.map((item) => (
-                  <li
-                    className="group flex gap-3 justify-start p-1"
+                  <TaskWrap
                     key={`item-${item.id}`}
-                  >
-                    <RadioButton
-                      centerColor="bg-[#F43F5E]"
-                      handleEditIsComplete={handleEditIsComplete}
-                      item={item}
-                    />
-                    <TaskInput
-                      setTextToday={setTextToday}
-                      setTextOther={setTextOther}
-                      setTextTomorrow={setTextTomorrow}
-                      updateTodo={updateTodo}
-                      item={item}
-                    />
-                    <div className="invisible group-hover:visible">
-                      <div className="flex invisible group-hover:visible gap-2 items-center mr-6 text-[#C2C6D2] hover:cursor-pointer">
-                        <MdOutlineContentCopy />
-                        <CgTrash />
-                      </div>
-                    </div>
-                  </li>
+                    updateTodo={updateTodo}
+                    item={item}
+                  />
                 ))}
               </ul>
-              <div className="flex justify-start p-1">
-                {isAddTask ? (
-                  <>
-                    <div className="aspect-square h-5 rounded-full border-2 border-[#C2C6D2]"></div>
-
-                    <input
-                      type="text"
-                      value={task.value}
-                      onChange={task.handleChangeEvent}
-                      onKeyPress={async (e) => {
-                        if (e.key === "Enter" && !isSending) {
-                          setIsSending(true);
-                          await task.addTodoFunction();
-                          setIsSending(false);
-                        }
-                        setAddTask(false);
-                      }}
-                      onBlur={async () => {
-                        //同じ文言であれば編集しないようにする
-                        if (!isSending) {
-                          setIsSending(true);
-                          await task.addTodoFunction();
-                          setIsSending(false);
-                        }
-                        setAddTask(false);
-                      }}
-                      className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 cursor-pointer caret-[#F43F5E]"
-                      // placeholder={item.task}
-                    />
-                  </>
-                ) : (
-                  <>
-                    <HiPlusCircle size={20} className="text-[#C2C6D2]" />
-                    <button
-                      onClick={handleClickButton}
-                      className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 caret-[#F43F5E]"
-                    >
-                      タスクを追加する
-                    </button>
-                  </>
-                )}
-              </div>
+              <NewTask day={task.day} updateTodo={updateTodo} />
             </div>
           </div>
         ))}

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -19,6 +19,7 @@ export const Index: VFC = () => {
   const [todoTomorrow, setTodoTomorrow] = useState<TodoType[]>([]);
   const [todoOther, setTodoOther] = useState<TodoType[]>([]);
   const [isSending, setIsSending] = useState<boolean>(false);
+  const [isAddTask, setAddTask] = useState<boolean>(false);
 
   //テスト用
   const [target, setTarget] = useState<number>(0);
@@ -127,6 +128,10 @@ export const Index: VFC = () => {
     },
   ];
 
+  const handleClickButton = () => {
+    setAddTask(true);
+  };
+
   return (
     <>
       <div className="grid grid-cols-3 gap-4 my-8 mx-12">
@@ -160,21 +165,46 @@ export const Index: VFC = () => {
                 ))}
               </ul>
               <div className="flex justify-start p-1">
-                <HiPlusCircle size={20} className="text-[#C2C6D2]" />
-                <input
-                  type="text"
-                  value={task.value}
-                  onChange={task.handleChangeEvent}
-                  onKeyPress={async (e) => {
-                    if (e.key === "Enter" && !isSending) {
-                      setIsSending(true);
-                      await task.addTodoFunction();
-                      setIsSending(false);
-                    }
-                  }}
-                  className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 caret-[#F43F5E]"
-                  placeholder="タスクを追加する"
-                />
+                {isAddTask ? (
+                  <>
+                    <div className="aspect-square h-5 rounded-full border-2 border-[#C2C6D2]"></div>
+
+                    <input
+                      type="text"
+                      value={task.value}
+                      onChange={task.handleChangeEvent}
+                      onKeyPress={async (e) => {
+                        if (e.key === "Enter" && !isSending) {
+                          setIsSending(true);
+                          await task.addTodoFunction();
+                          setIsSending(false);
+                        }
+                        setAddTask(false);
+                      }}
+                      onBlur={async () => {
+                        //同じ文言であれば編集しないようにする
+                        if (!isSending) {
+                          setIsSending(true);
+                          await task.addTodoFunction();
+                          setIsSending(false);
+                        }
+                        setAddTask(false);
+                      }}
+                      className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 cursor-pointer caret-[#F43F5E]"
+                      // placeholder={item.task}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <HiPlusCircle size={20} className="text-[#C2C6D2]" />
+                    <button
+                      onClick={handleClickButton}
+                      className="h-5 placeholder:text-[#C2C6D2] border-0 focus:ring-0 caret-[#F43F5E]"
+                    >
+                      タスクを追加する
+                    </button>
+                  </>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fixes #35 

## 変更内容（必須）

- 全体的にリファクタリングした
- タスクのボタンの色を今日、明日、今度するの色に合わせた
- タスクを追加するボタンを押してタスク追加後、エンターを押すとさらに追加できるようにした
- タスク追加中に別のところにカーソルを合わせても保存されるようにした
- 全体的に見た目を整えた

## 確認して欲しい項目（必須）

- [x] 写真のような見た目になっているか
- [x] ボタンの色がそれぞれ違うようになっているか
- [x] タスクを追加するボタンを押してエンターを押すと、さらに新しく追加できるようになっているか
- [x] タスク追加中に他のところをクリックしても、タスクが追加されるようになっているか

## どうやって確認するのか（必須）

1. タスクを追加するときに、エンターを押して追加するやり方と、別の部分にカーソルを合わせるやり方両方やってみてください。

## 新たな課題

- タスク追加中にラジオボタンを押すと、カーソルが外れるのでタスクが追加されてしまう
- その後、追加されたタスクにはボタンがついていないが、タスクを追加するを再びおすと、そっちに色がついている
- 別イシューで直します

<img width="900" alt="スクリーンショット 2022-02-20 12 57 30" src="https://user-images.githubusercontent.com/74912714/154828091-81d044ce-2855-4f22-8876-9ac0f71bd9a0.png">

