### PR TITLE
アカウント連携画面の作成

### DIFF
--- a/pages/mypage/connect/index.tsx
+++ b/pages/mypage/connect/index.tsx
@@ -1,0 +1,10 @@
+import type { CustomNextPage } from "next";
+import { FixedLayout } from "src/layout";
+
+import { Connect } from "../../../src/pages/mypage/connect/index";
+
+const ConnectPage: CustomNextPage = () => <Connect />;
+
+ConnectPage.getLayout = FixedLayout;
+
+export default ConnectPage;

--- a/src/pages/mypage/connect/index.spec.tsx
+++ b/src/pages/mypage/connect/index.spec.tsx
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { Profile } from "src/pages/mypage/profile";
+
+describe("Profile", () => {
+  it("renders a heading", () => {
+    render(<Profile />);
+    const heading = screen.getByRole("heading", { name: /profile/i });
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/src/pages/mypage/connect/index.tsx
+++ b/src/pages/mypage/connect/index.tsx
@@ -1,0 +1,94 @@
+import { useRouter } from "next/router";
+import type { VFC } from "react";
+import { IconContext } from "react-icons";
+import { FaApple } from "react-icons/fa";
+import { FcGoogle } from "react-icons/fc";
+import { HiOutlineChevronRight } from "react-icons/hi";
+
+export const Connect: VFC = () => {
+  const router = useRouter();
+  const handleClick = (URL: string) => {
+    router.push(`${URL}`);
+  };
+
+  const List1 = [
+    {
+      url: "/mypage/profile",
+      icon: <FcGoogle />,
+      title: <>Google</>,
+    },
+    {
+      url: "/mypage/connect",
+      icon: <FaApple />,
+      title: <>Apple</>,
+    },
+  ];
+
+  type ButtonProps = {
+    item: { url: string; title: JSX.Element; icon?: JSX.Element };
+  };
+
+  const Button = (props: ButtonProps) => {
+    const { item } = props;
+    return (
+      <>
+        <div className="flex justify-between items-center px-2 mb-5 w-full h-10 font-bold rounded-sm">
+          <div className="flex items-center">
+            <IconContext.Provider value={{ size: "1.5em", className: "mr-5" }}>
+              {item.icon}
+            </IconContext.Provider>
+            <p className="text-base">{item.title}</p>
+          </div>
+          <button className=" px-7 text-base bg-gray-100 hover:bg-blue-500 rounded-full border-none btn btn-outline">
+            解除する
+          </button>
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <>
+      <div className="m-auto mt-6 w-1/3">
+        <div className="m-auto mt-5 w-full text-xl font-bold">
+          <div className="flex items-center p-2 py-2 mb-1 h-10 text-base">
+            <p
+              className=" hover:underline cursor-pointer"
+              onClick={() => handleClick("/")}
+            >
+              ホーム
+            </p>
+            <HiOutlineChevronRight size={22} className=" mx-5 text-gray-400" />
+            <p
+              className=" hover:underline cursor-pointer"
+              onClick={() => handleClick("/mypage/connect")}
+            >
+              アカウントの連携
+            </p>
+          </div>
+          <div className="p-2 py-2 mb-14 text-4xl">アカウント連携</div>
+          {List1.map((item, index) => (
+            <Button item={item} key={index} />
+          ))}
+          <div className="p-2 py-2 mt-14 mb-2 text-lg text-gray-400">
+            アカウント操作
+          </div>
+
+          <button
+            className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm"
+            onClick={() => handleClick("/")}
+          >
+            ログアウト
+          </button>
+
+          <button
+            className="block p-2 font-bold text-red-500 hover:bg-slate-100 rounded-sm"
+            onClick={() => handleClick("/")}
+          >
+            アカウント削除
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/pages/mypage/connect/index.tsx
+++ b/src/pages/mypage/connect/index.tsx
@@ -1,15 +1,21 @@
 import { useRouter } from "next/router";
 import type { VFC } from "react";
+import { useCallback } from "react";
 import { IconContext } from "react-icons";
 import { FaApple } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
 import { HiOutlineChevronRight } from "react-icons/hi";
+import { client } from "src/lib/SupabaseClient";
 
 export const Connect: VFC = () => {
   const router = useRouter();
   const handleClick = (URL: string) => {
     router.push(`${URL}`);
   };
+
+  const handleLogout = useCallback(() => {
+    client.auth.signOut();
+  }, []);
 
   const List1 = [
     {
@@ -76,7 +82,7 @@ export const Connect: VFC = () => {
 
           <button
             className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm"
-            onClick={() => handleClick("/")}
+            onClick={handleLogout}
           >
             ログアウト
           </button>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -15,7 +15,7 @@ export const MyPage: VFC = () => {
       title: <p>プロフィール設定</p>,
     },
     {
-      url: "/",
+      url: "/mypage/connect",
       title: <p>アカウント設定</p>,
     },
     {


### PR DESCRIPTION
Fixes #58

## 変更内容（必須）

- アカウント連携画面作成

## 確認して欲しい項目（必須）

- [x] /mypage/connectに遷移してページが表示されるか

## どうやって確認するのか（必須）

1./mypage/connectに遷移する

## 備考

- 連携機能はまだないので、「連携する」のみ表示させている
