### PR TITLE
:bug: dnd後にローカルのTodoリストをアップデート

### DIFF
--- a/src/component/Dndkit/index.tsx
+++ b/src/component/Dndkit/index.tsx
@@ -220,12 +220,13 @@ export const Dndkit = (props: Props) => {
       if (!isOk) {
         alert("更新に失敗しました。");
       } else {
+        updateTodo();
         setActiveId(-1);
         setTargetContainer(null);
         setTargetIndex(-1);
       }
     }
-  }, [activeId, targetContainer, targetIndex]);
+  }, [activeId, targetContainer, targetIndex, updateTodo]);
 
   useEffect(() => {
     if (activeId != -1 && targetContainer && targetIndex != -1) {


### PR DESCRIPTION
Fixes #64

## 変更内容（必須）

例）Todo リストを追加できるようにするため

- dnd後にupdateTodoを呼び出し、DBの内容を再度fetchするようにした
-

## 確認して欲しい項目（必須）

- [ ] dndなどの動作に不具合が生じていないか
- [ ] sortkeyがDBの内容と一致し、最新のものになっているか (ここはタスクコピーを実装している @hello-ty さんにお願いします！)

## どうやって確認するのか（必須）

1. 実際に動かしてみて、今まで通りにdndできるか確認
1. sortkeyを表示してみて、最新のものに更新されているか確認 (@hello-ty さん向け)

## 新たな課題

-
-

## 備考

-
-
