### PR TITLE
サインアウト機能の実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     }
   },
   "dependencies": {
+    "@headlessui/react": "^1.5.0",
     "@supabase/supabase-js": "^1.30.2",
     "@supabase/ui": "^0.36.3",
     "daisyui": "^2.1.0",

--- a/src/component/Modal/AlertModal.tsx
+++ b/src/component/Modal/AlertModal.tsx
@@ -1,46 +1,82 @@
-import type { VFC } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import type { Dispatch, SetStateAction, VFC } from "react";
+import { Fragment } from "react";
 
 type Props = {
   title: string;
   message: string;
   onClick: () => void;
-  id: string;
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
 };
 
 export const AlertModal: VFC<Props> = (props) => {
-  const { id, message, onClick, title } = props;
-  return (
-    <div>
-      <input type="checkbox" id={id} className="modal-toggle" />
-      <div className="modal">
-        <div className="mx-auto max-w-md modal-box">
-          <h3 className="text-2xl font-bold text-center">{title}</h3>
-          <p className="py-4 font-thin text-center">{message}</p>
-          <div className="flex gap-4 justify-center modal-action">
-            {/* <button> */}
-            <label
-              htmlFor={id}
-              className="py-3 px-8 text-[#070417] bg-[#F1F5F9] rounded-full border-none hover:opacity-70 btn btn-outline"
-            >
-              キャンセル
-            </label>
-            {/* </button> */}
-            {/* <button
-              onClick={onClick}
-              className="block py-3 px-14 text-white bg-[#EF4444] rounded-full hover:opacity-70"
-            > */}
-            <label
-              htmlFor={id}
-              onClick={onClick}
-              className=" py-3 px-12 text-white bg-[#EF4444] rounded-full hover:opacity-70 btn btn-outline"
-            >
-              OK
-            </label>
+  const { isOpen, message, onClick, setIsOpen, title } = props;
 
-            {/* </button> */}
-          </div>
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog
+        as="div"
+        className="overflow-y-auto fixed inset-0 z-10 bg-gray-500 bg-opacity-75 transition-opacity"
+        onClose={() => setIsOpen(false)}
+      >
+        <div className="px-4 min-h-screen text-center">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Dialog.Overlay className="fixed inset-0" />
+          </Transition.Child>
+
+          {/* This element is to trick the browser into centering the modal contents. */}
+          <span
+            className="inline-block h-screen align-middle"
+            aria-hidden="true"
+          >
+            &#8203;
+          </span>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <div className="inline-block overflow-hidden p-6 my-8 w-full max-w-md text-left align-middle bg-white rounded-2xl shadow-xl transition-all">
+              <Dialog.Title as="h3" className="text-2xl font-bold text-center">
+                {title}
+              </Dialog.Title>
+              <div className="mt-2">
+                <p className="py-4 font-thin text-center">{message}</p>
+              </div>
+
+              <div className="mt-4">
+                <div className="flex gap-4 justify-center">
+                  <button
+                    className="py-3 px-8 text-[#070417] bg-[#F1F5F9] rounded-full border-none hover:opacity-70 "
+                    onClick={() => setIsOpen(false)}
+                  >
+                    キャンセル
+                  </button>
+                  <button
+                    onClick={onClick}
+                    className=" py-3 px-12 text-white bg-[#EF4444] rounded-full hover:opacity-70"
+                  >
+                    OK
+                  </button>
+                </div>
+              </div>
+            </div>
+          </Transition.Child>
         </div>
-      </div>
-    </div>
+      </Dialog>
+    </Transition>
   );
 };

--- a/src/component/Modal/AlertModal.tsx
+++ b/src/component/Modal/AlertModal.tsx
@@ -1,0 +1,46 @@
+import type { VFC } from "react";
+
+type Props = {
+  title: string;
+  message: string;
+  onClick: () => void;
+  id: string;
+};
+
+export const AlertModal: VFC<Props> = (props) => {
+  const { id, message, onClick, title } = props;
+  return (
+    <div>
+      <input type="checkbox" id={id} className="modal-toggle" />
+      <div className="modal">
+        <div className="mx-auto max-w-md modal-box">
+          <h3 className="text-2xl font-bold text-center">{title}</h3>
+          <p className="py-4 font-thin text-center">{message}</p>
+          <div className="flex gap-4 justify-center modal-action">
+            {/* <button> */}
+            <label
+              htmlFor={id}
+              className="py-3 px-8 text-[#070417] bg-[#F1F5F9] rounded-full border-none hover:opacity-70 btn btn-outline"
+            >
+              キャンセル
+            </label>
+            {/* </button> */}
+            {/* <button
+              onClick={onClick}
+              className="block py-3 px-14 text-white bg-[#EF4444] rounded-full hover:opacity-70"
+            > */}
+            <label
+              htmlFor={id}
+              onClick={onClick}
+              className=" py-3 px-12 text-white bg-[#EF4444] rounded-full hover:opacity-70 btn btn-outline"
+            >
+              OK
+            </label>
+
+            {/* </button> */}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/component/Modal/AlertModal.tsx
+++ b/src/component/Modal/AlertModal.tsx
@@ -60,14 +60,14 @@ export const AlertModal: VFC<Props> = (props) => {
               <div className="mt-4">
                 <div className="flex gap-4 justify-center">
                   <button
-                    className="py-3 px-8 text-[#070417] bg-[#F1F5F9] rounded-full border-none hover:opacity-70 "
+                    className="z-10 py-3 px-8 text-[#070417] bg-[#F1F5F9] rounded-full border-none hover:opacity-70"
                     onClick={() => setIsOpen(false)}
                   >
                     キャンセル
                   </button>
                   <button
                     onClick={onClick}
-                    className=" py-3 px-12 text-white bg-[#EF4444] rounded-full hover:opacity-70"
+                    className="z-10 py-3 px-12 text-white bg-[#EF4444] rounded-full hover:opacity-70"
                   >
                     OK
                   </button>

--- a/src/component/TaskWrap/index.tsx
+++ b/src/component/TaskWrap/index.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from "react";
 import { CgTrash } from "react-icons/cg";
 import { MdOutlineContentCopy } from "react-icons/md";
 import { RadioButton } from "src/component/RadioButton";
-import { TaskInput } from "src/component/TaskInput";
+import { TaskInput } from "src/component/taskInput";
 import type { TodoType } from "src/lib/SupabaseClient";
 import { addTodo, deleteTodo, editIsComplete } from "src/lib/SupabaseClient";
 import type { BgColorProps, DayProps, OutLineProps } from "src/type/type";

--- a/src/layout/AuthLayout.tsx
+++ b/src/layout/AuthLayout.tsx
@@ -1,6 +1,6 @@
-import { Auth, Button, IconLogOut } from "@supabase/ui";
+import { Auth } from "@supabase/ui";
 import type { CustomLayout } from "next";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { client } from "src/lib/SupabaseClient";
 
 import { Footer } from "./Footer";
@@ -16,14 +16,9 @@ type Props = {
  */
 export const AuthLayout: CustomLayout = (props: Props) => {
   const { user } = Auth.useUser();
-
   const [isMounted, setIsMounted] = useState<boolean>(false);
 
   const { children } = props;
-
-  const handleLogout = useCallback(() => {
-    client.auth.signOut();
-  }, []);
 
   useEffect(() => {
     setIsMounted(true);
@@ -39,7 +34,7 @@ export const AuthLayout: CustomLayout = (props: Props) => {
           {isMounted && user ? (
             <div>
               <div>{children}</div>
-              <div className="flex justify-end my-4 mx-2">
+              {/* <div className="flex justify-end my-4 mx-2">
                 <Button
                   size="medium"
                   icon={<IconLogOut />}
@@ -47,7 +42,7 @@ export const AuthLayout: CustomLayout = (props: Props) => {
                 >
                   Sign out
                 </Button>
-              </div>
+              </div> */}
             </div>
           ) : (
             <div>

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,7 +1,7 @@
 import type { VFC } from "react";
 import { useCallback } from "react";
 import { useEffect, useState } from "react";
-import { Dndkit } from "src/component/Dndkit";
+import { Dndkit } from "src/component/dndkit";
 import { taskElement } from "src/constants/TaskElement";
 import type { TodoType } from "src/lib/SupabaseClient";
 import { getTodo } from "src/lib/SupabaseClient";

--- a/src/pages/mypage/connect/index.tsx
+++ b/src/pages/mypage/connect/index.tsx
@@ -5,6 +5,7 @@ import { IconContext } from "react-icons";
 import { FaApple } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
 import { HiOutlineChevronRight } from "react-icons/hi";
+import { AlertModal } from "src/component/Modal/AlertModal";
 import { client } from "src/lib/SupabaseClient";
 
 export const Connect: VFC = () => {
@@ -15,9 +16,27 @@ export const Connect: VFC = () => {
 
   const handleLogout = useCallback(() => {
     client.auth.signOut();
+    router.replace("/");
   }, []);
 
-  const List1 = [
+  const handleModalActions = [
+    {
+      id: "signOut-modal",
+      title: "ログアウト",
+      message: "ログアウトしてよろしいですか？",
+      onClick: () => handleLogout,
+      buttonChildren: "ログアウト",
+    },
+    {
+      id: "account-modal",
+      title: "アカウントの削除",
+      message: "アカウント完全に削除してよろしいですか？",
+      onClick: () => alert("アカウントを削除しました"),
+      buttonChildren: "アカウントの削除",
+    },
+  ];
+
+  const ButtonList = [
     {
       url: "/mypage/profile",
       icon: <FcGoogle />,
@@ -45,7 +64,7 @@ export const Connect: VFC = () => {
             </IconContext.Provider>
             <p className="text-base">{item.title}</p>
           </div>
-          <button className=" px-7 text-base bg-gray-100 hover:bg-blue-500 rounded-full border-none btn btn-outline">
+          <button className="px-7 text-base bg-gray-100 hover:bg-blue-500 rounded-full border-none btn btn-outline">
             解除する
           </button>
         </div>
@@ -73,18 +92,19 @@ export const Connect: VFC = () => {
             </p>
           </div>
           <div className="p-2 py-2 mb-14 text-4xl">アカウント連携</div>
-          {List1.map((item, index) => (
+          {ButtonList.map((item, index) => (
             <Button item={item} key={index} />
           ))}
           <div className="p-2 py-2 mt-14 mb-2 text-lg text-gray-400">
             アカウント操作
           </div>
-
-          <button
-            className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm"
-            onClick={handleLogout}
+          {/* <button
+            className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm modal-button"
+            // onClick={handleLogout}
           >
-            ログアウト
+            <label htmlFor="my-modal" className="modal-button">
+              ログアウト
+            </label>
           </button>
 
           <button
@@ -92,7 +112,23 @@ export const Connect: VFC = () => {
             onClick={() => handleClick("/")}
           >
             アカウント削除
-          </button>
+          </button> */}
+
+          {handleModalActions.map((item) => (
+            <div key={item.id}>
+              <button className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm modal-button">
+                <label htmlFor={item.id} className="modal-button">
+                  {item.buttonChildren}
+                </label>
+              </button>
+              <AlertModal
+                id={item.id}
+                message={item.message}
+                title={item.title}
+                onClick={() => item.onClick}
+              />
+            </div>
+          ))}
         </div>
       </div>
     </>

--- a/src/pages/mypage/connect/index.tsx
+++ b/src/pages/mypage/connect/index.tsx
@@ -104,22 +104,6 @@ export const Connect: VFC = () => {
           <div className="p-2 py-2 mt-14 mb-2 text-lg text-gray-400">
             アカウント操作
           </div>
-          {/* <button
-            className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm modal-button"
-            // onClick={handleLogout}
-          >
-            <label htmlFor="my-modal" className="modal-button">
-              ログアウト
-            </label>
-          </button>
-
-          <button
-            className="block p-2 font-bold text-red-500 hover:bg-slate-100 rounded-sm"
-            onClick={() => handleClick("/")}
-          >
-            アカウント削除
-          </button> */}
-
           {handleModalActions.map((item) => (
             <div key={item.title}>
               <button

--- a/src/pages/mypage/connect/index.tsx
+++ b/src/pages/mypage/connect/index.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import type { VFC } from "react";
+import { useState } from "react";
 import { useCallback } from "react";
 import { IconContext } from "react-icons";
 import { FaApple } from "react-icons/fa";
@@ -14,6 +15,9 @@ export const Connect: VFC = () => {
     router.push(`${URL}`);
   };
 
+  const [isOpenLogout, setIsOpenLogout] = useState(false);
+  const [isOpenAccount, setIsOpenAccount] = useState(false);
+
   const handleLogout = useCallback(() => {
     client.auth.signOut();
     router.replace("/");
@@ -21,14 +25,16 @@ export const Connect: VFC = () => {
 
   const handleModalActions = [
     {
-      id: "signOut-modal",
+      isOpen: isOpenLogout,
+      setIsOpen: setIsOpenLogout,
       title: "ログアウト",
       message: "ログアウトしてよろしいですか？",
-      onClick: () => handleLogout,
+      onClick: handleLogout,
       buttonChildren: "ログアウト",
     },
     {
-      id: "account-modal",
+      isOpen: isOpenAccount,
+      setIsOpen: setIsOpenAccount,
       title: "アカウントの削除",
       message: "アカウント完全に削除してよろしいですか？",
       onClick: () => alert("アカウントを削除しました"),
@@ -115,17 +121,21 @@ export const Connect: VFC = () => {
           </button> */}
 
           {handleModalActions.map((item) => (
-            <div key={item.id}>
-              <button className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm modal-button">
-                <label htmlFor={item.id} className="modal-button">
-                  {item.buttonChildren}
-                </label>
+            <div key={item.title}>
+              <button
+                className="p-2 mb-3 font-bold text-red-500 hover:bg-slate-100 rounded-sm modal-button"
+                // eslint-disable-next-line react/jsx-handler-names
+                onClick={() => item.setIsOpen(true)}
+              >
+                {item.buttonChildren}
               </button>
               <AlertModal
-                id={item.id}
+                isOpen={item.isOpen}
+                setIsOpen={item.setIsOpen}
                 message={item.message}
                 title={item.title}
-                onClick={() => item.onClick}
+                // eslint-disable-next-line react/jsx-handler-names
+                onClick={item.onClick}
               />
             </div>
           ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -569,6 +569,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@headlessui/react@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
+  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.3.tgz#f2564c744b387775b436418491f15fce6601f63e"


### PR DESCRIPTION
## 変更内容（必須）

例）Todo リストを追加できるようにするため

- サインアウト機能を現在のデザイン部分から実行出来るように修正
- 各処理の際に該当のModalが出るように修正

## 確認して欲しい項目（必須）

- [x] 今回、ModalにHeadless Uiを使用している為`yarn add @headlessui/react`を実行してから作業を開始する
- [x] /mypage/connectページからログアウトを押す
- [x] Okを押してログアウトできればOK
- [x] ついでにアカウント削除のボタンを押してもモーダルが出るか確認する（処理は未実装）

## どうやって確認するのか（必須）

1.　上記の通り確認
1.

## 新たな課題

- アカウント削除機能は調べた感じsupabaseのRLSで実行する必要あり？（[こちら](https://zenn.dev/panda_program/scraps/828e48b9940f3c)の記事参考）
-

## 備考

-
-
