### PR TITLE
現状alertを使用している処理をreact-hot-toastなどに置き換えたい

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-error-boundary": "3.1.4",
+    "react-hot-toast": "^2.2.0",
     "react-icons": "^4.3.1"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { Auth } from "@supabase/ui";
 import type { CustomAppPage } from "next/app";
 import Head from "next/head";
 import { memo, useEffect } from "react";
+import { Toaster } from "react-hot-toast";
 import { AuthLayout } from "src/layout";
 import { client } from "src/lib/SupabaseClient";
 
@@ -33,6 +34,7 @@ const App: CustomAppPage = ({ Component, pageProps }) => {
       <div className="text-slate-800 dark:text-[#C2C6D2] bg-white dark:bg-darkbg">
         <Auth.UserContextProvider supabaseClient={client}>
           <AuthLayout>
+            <Toaster />
             <Component {...pageProps} />
           </AuthLayout>
         </Auth.UserContextProvider>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -7,10 +7,11 @@ import { useCallback, useEffect, useState } from "react";
 import { HiOutlineLogout } from "react-icons/hi";
 import { Avatar } from "src/components/ui/Avatar";
 import { addNewProfile, client, getProfile } from "src/lib/SupabaseClient";
+import { useToast } from "src/lib/ToastHooks";
 
 export const Header = () => {
   const { user } = Auth.useUser();
-
+  const { errorToast } = useToast();
   const [avatar, setAvatar] = useState<string>("");
   const router = useRouter();
 
@@ -29,7 +30,7 @@ export const Header = () => {
             : "";
           const isOk = await addNewProfile(uid, username, avatar_url);
           if (!isOk) {
-            alert("プロフィールの新規登録に失敗しました。");
+            errorToast("プロフィールの新規登録に失敗しました。");
           } else {
             setAvatar(avatar_url);
           }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -37,7 +37,7 @@ export const Header = () => {
         }
       }
     },
-    [user]
+    [errorToast, user]
   );
 
   useEffect(() => {

--- a/src/components/TaskContainer/NewTask/index.tsx
+++ b/src/components/TaskContainer/NewTask/index.tsx
@@ -53,7 +53,7 @@ export const NewTask = (props: Props) => {
         }
       }
     },
-    [text, user, updateTodo]
+    [text, user, updateTodo, errorToast]
   );
 
   const handleClickButton = () => {

--- a/src/components/TaskContainer/NewTask/index.tsx
+++ b/src/components/TaskContainer/NewTask/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { HiPlusSm } from "react-icons/hi";
 import type { TaskType } from "src/lib/Datetime";
 import { addTodo } from "src/lib/SupabaseClient";
+import { useToast } from "src/lib/ToastHooks";
 import type { CaretColorProps } from "src/type/type";
 
 type Props = {
@@ -16,6 +17,7 @@ export const NewTask = (props: Props) => {
   const [isSending, setIsSending] = useState<boolean>(false);
   const [text, setText] = useState<string>("");
   const [isAddTask, setAddTask] = useState<boolean>(false);
+  const { errorToast } = useToast();
 
   const caretColor = useMemo<CaretColorProps>(
     () =>
@@ -47,7 +49,7 @@ export const NewTask = (props: Props) => {
           updateTodo();
           setText("");
         } else {
-          alert("タスクの追加に失敗しました");
+          errorToast("タスクの追加に失敗しました");
         }
       }
     },

--- a/src/components/TaskContainer/TaskInput/index.tsx
+++ b/src/components/TaskContainer/TaskInput/index.tsx
@@ -3,6 +3,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useState } from "react";
 import type { TodoType } from "src/lib/SupabaseClient";
 import { editTodo } from "src/lib/SupabaseClient";
+import { useToast } from "src/lib/ToastHooks";
 import type { CaretColorProps } from "src/type/type";
 
 type Props = {
@@ -17,6 +18,7 @@ export const TaskInput = (props: Props) => {
   const { caretColor, item, setText, text, updateTodo } = props;
   const { user } = Auth.useUser();
   const [isSending, setIsSending] = useState<boolean>(false);
+  const { errorToast } = useToast();
 
   const inputstyle = "line-through text-[#C2C6D2] dark:text-gray-400";
   const lineThrough: string = item.iscomplete ? inputstyle : "";
@@ -40,12 +42,12 @@ export const TaskInput = (props: Props) => {
         updateTodo();
         setText(text);
       } else {
-        alert("タスクの変更に失敗しました");
+        errorToast("タスクの変更に失敗しました");
       }
     } else {
       setText(item.task);
     }
-  }, [text, user, item.id, item.task, updateTodo, setText]);
+  }, [text, user, item.id, item.task, updateTodo, setText, errorToast]);
 
   return (
     <>

--- a/src/components/TaskContainer/TaskWrap/index.tsx
+++ b/src/components/TaskContainer/TaskWrap/index.tsx
@@ -8,6 +8,7 @@ import { TaskInput } from "src/components/TaskContainer/TaskInput";
 import { RadioButton } from "src/components/ui/RadioButton";
 import type { TodoType } from "src/lib/SupabaseClient";
 import { addTodo, deleteTodo, editIsComplete } from "src/lib/SupabaseClient";
+import { useToast } from "src/lib/ToastHooks";
 import type { BgColorProps, CaretColorProps, DayProps } from "src/type/type";
 
 type Props = {
@@ -19,6 +20,7 @@ type Props = {
 export const TaskWrap: VFC<Props> = (props) => {
   const { day, item, updateTodo } = props;
   const { user } = Auth.useUser();
+  const { errorToast } = useToast();
   const [text, setText] = useState<string>(item.task);
 
   const caretColor = useMemo<CaretColorProps>(
@@ -48,12 +50,12 @@ export const TaskWrap: VFC<Props> = (props) => {
         if (isSuccess) {
           updateTodo();
         } else {
-          alert("isComplete処理に失敗しました。");
+          errorToast("isComplete処理に失敗しました。");
         }
       } else {
       }
     },
-    [user, updateTodo]
+    [user, updateTodo, errorToast]
   );
 
   const handleDelete = async (id: number) => {
@@ -62,7 +64,7 @@ export const TaskWrap: VFC<Props> = (props) => {
       if (isSuccess) {
         updateTodo();
       } else {
-        alert("タスクの削除に失敗しました");
+        errorToast("タスクの削除に失敗しました");
       }
     }
   };
@@ -75,11 +77,11 @@ export const TaskWrap: VFC<Props> = (props) => {
         if (isSuccess) {
           updateTodo();
         } else {
-          alert("タスクの追加に失敗しました");
+          errorToast("タスクの追加に失敗しました");
         }
       }
     },
-    [text, user, updateTodo]
+    [text, user, updateTodo, errorToast]
   );
 
   return (

--- a/src/components/TaskContainer/index.tsx
+++ b/src/components/TaskContainer/index.tsx
@@ -23,6 +23,7 @@ import type { TaskType } from "src/lib/Datetime";
 import type { TodoType } from "src/lib/SupabaseClient";
 import { getTodo } from "src/lib/SupabaseClient";
 import { moveTodo } from "src/lib/SupabaseClient";
+import { useToast } from "src/lib/ToastHooks";
 import type { MapTaskElement } from "src/type/type";
 
 import { Container } from "./container";
@@ -53,6 +54,7 @@ export const Dndkit = (props: Props) => {
   const [sourceContainer, setSourceContainer] = useState<TaskType | null>(null);
   const [targetContainer, setTargetContainer] = useState<TaskType | null>(null);
   const [targetIndex, setTargetIndex] = useState<number>(-1);
+  const { errorToast } = useToast();
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -221,7 +223,7 @@ export const Dndkit = (props: Props) => {
       const todo = await getTodo(targetContainer);
       const isOk = await moveTodo(todo, activeId, targetIndex, targetContainer);
       if (!isOk) {
-        alert("更新に失敗しました。");
+        errorToast("更新に失敗しました。");
       } else {
         updateTodo();
         setActiveId(-1);
@@ -229,7 +231,7 @@ export const Dndkit = (props: Props) => {
         setTargetIndex(-1);
       }
     }
-  }, [activeId, targetContainer, targetIndex, updateTodo]);
+  }, [activeId, errorToast, targetContainer, targetIndex, updateTodo]);
 
   useEffect(() => {
     if (activeId != -1 && targetContainer && targetIndex != -1) {

--- a/src/lib/SupabaseClient.ts
+++ b/src/lib/SupabaseClient.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import toast from "react-hot-toast";
 import type { TaskType } from "src/lib/Datetime";
 import { getDate, getDateEnd } from "src/lib/Datetime";
 
@@ -106,7 +107,7 @@ export const deleteTodo = async (id: number) => {
     .eq("id", id);
 
   if (error) {
-    alert("削除に失敗しました");
+    toast.error("削除に失敗しました");
     return;
   } else {
     return data;

--- a/src/lib/ToastHooks.ts
+++ b/src/lib/ToastHooks.ts
@@ -1,0 +1,12 @@
+import toast from "react-hot-toast";
+
+export const useToast = () => {
+  const successToast = (msg: string) => toast.success(msg);
+  const errorToast = (msg: string) => toast.error(msg);
+  const warnningToast = (msg: string) => toast(msg, { icon: "🤔" });
+  return {
+    successToast,
+    errorToast,
+    warnningToast,
+  };
+};

--- a/src/page/mypage/profile/index.tsx
+++ b/src/page/mypage/profile/index.tsx
@@ -8,6 +8,7 @@ import {
   updateProfile,
   uploadAvatar,
 } from "src/lib/SupabaseClient";
+import { useToast } from "src/lib/ToastHooks";
 
 export const Profile: NextPage = () => {
   const { user } = Auth.useUser();
@@ -16,6 +17,7 @@ export const Profile: NextPage = () => {
   const [editName, setEditName] = useState<string>(username);
   const [previewIcon, setPreviewIcon] = useState<string>(avatar);
   const [previewIconFile, setPreviewIconFile] = useState<File | null>(null);
+  const { errorToast, successToast } = useToast();
 
   const iconInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -53,14 +55,14 @@ export const Profile: NextPage = () => {
   const handleSave = useCallback(async () => {
     if (user) {
       if (editName == "") {
-        alert("名前を入力してください。");
+        errorToast("名前を入力してください。");
         return;
       }
       let isIconChanged = false;
       if (previewIconFile) {
         const isOk = await uploadAvatar(user.id, previewIconFile);
         if (!isOk) {
-          alert("アイコンのアップロードに失敗しました。");
+          errorToast("アイコンのアップロードに失敗しました。");
           return;
         }
         isIconChanged = true;
@@ -71,13 +73,21 @@ export const Profile: NextPage = () => {
         isIconChanged ? "storage" : avatar
       );
       if (!isOkUpdate) {
-        alert("プロフィールの更新に失敗しました。");
+        errorToast("プロフィールの更新に失敗しました。");
       } else {
         fetchProfile();
-        alert("プロフィールを更新しました。");
+        successToast("プロフィールを更新しました。");
       }
     }
-  }, [user, editName, previewIconFile, avatar, fetchProfile]);
+  }, [
+    user,
+    editName,
+    previewIconFile,
+    avatar,
+    errorToast,
+    fetchProfile,
+    successToast,
+  ]);
 
   useEffect(() => {
     if (user) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,6 +2881,11 @@ globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.1:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.8.tgz#e592c04d093cb38f77b38cfcb012b7811c85765e"
+  integrity sha512-S0C85gCzcfFCMSdjD/CxyQMt1rbf2qEg6hmDzxk2FfD7+7Ogk55m8ZFUMtqNaZM4VVX/qaU9AzSORG+Gf4ZpAQ==
+
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
@@ -4620,6 +4625,13 @@ react-error-boundary@3.1.4:
   integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+react-hot-toast@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.2.0.tgz#ab6f4caed4214b9534f94bb8cfaaf21b051e62b9"
+  integrity sha512-248rXw13uhf/6TNDVzagX+y7R8J183rp7MwUMNkcrBRyHj/jWOggfXTGlM8zAOuh701WyVW+eUaWG2LeSufX9g==
+  dependencies:
+    goober "^2.1.1"
 
 react-icons@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
## 変更内容（必須）

例）Todo リストを追加できるようにするため

- alertで処理している部分をtoastに置き換えてユーザビリティを向上したい
-
## 確認して欲しい項目（必須）

- [x] プロフィール更新でtoastが出るか確認
- [x] その他各種エラーを任意で発生させることが出来れば挙動確認お願いします

## どうやって確認するのか（必須）

1. `yarn add react-hot-toast`をターミナルで実行
1. プロフィール更新を押す
 


## 新たな課題

- 100文字制限の部分は処理を止めたい為alertのまま実装しています。
-

## 備考

-
-
